### PR TITLE
Adds an opt-out mechanism that disables author-archive pages by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.env
+
+*.log
+
+composer.phar
+node_modules
+vendor

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,69 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b09582b2bd564b1cc46c92898aef2737",
+    "packages": [
+        {
+            "name": "yahnis-elsts/plugin-update-checker",
+            "version": "v5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
+                "reference": "845d65da93bcff31649ede00d9d73b1beadbb7f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/845d65da93bcff31649ede00d9d73b1beadbb7f0",
+                "reference": "845d65da93bcff31649ede00d9d73b1beadbb7f0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "load-v5p5.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Yahnis Elsts",
+                    "email": "whiteshadow@w-shadow.com",
+                    "homepage": "https://w-shadow.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A custom update checker for WordPress plugins and themes. Useful if you can't host your plugin in the official WP repository but still want it to support automatic updates.",
+            "homepage": "https://github.com/YahnisElsts/plugin-update-checker/",
+            "keywords": [
+                "automatic updates",
+                "plugin updates",
+                "theme updates",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/YahnisElsts/plugin-update-checker/issues",
+                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v5.5"
+            },
+            "time": "2024-10-16T14:25:00+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
## Changes proposed in this pull request

<!-- Using a starter sentence below, describe the changes made in this Pull Request and the reason for such changes. -->

This PR introduces an opt-out mechanism that **disables author-archive pages by default** and converts any direct request for `/author/{author}` into a 404 response.  
The behaviour can be toggled from themes or plugins via a single filter (`matchbox_disable_author_archive`).

---

### 🔍 Implementation details
* **Hook:**  The logic runs early on `template_redirect`.  
* **404 flow:**  
  * Detects real author–archive requests with `is_author()`.  
  * When archives are disabled it sets the query to 404, sends the correct headers, and renders the theme’s `404.php` if available.  
* **Filter:**  

```php
/**
 * Allows themes / plugins to keep or disable the author archive.
 *
 * @param bool $should_disable  Default true.  Return false to KEEP the archive.
 */
apply_filters( 'matchbox_disable_author_archive', true );
```

Example to *keep* author archives from a child-theme:

```php
add_filter( 'matchbox_disable_author_archive', '__return_false' );
```

---

Closes https://github.com/matchboxdesigngroup/matchbox-support/issues/12

## Pre-submit checklist

As the author of this pull request, I verify that:

- [ ] I have set the target branch to `main`.
- [ ] I have detailed the purpose of this Pull Request in a non-technical way.
- [ ] I have detailed how to test the changes in the Pull Request.
- [ ] I have detailed the functional tests required for approval.
- [ ] I have performed a self-review of my code to ensure it is DRY and follows the team's coding standards.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified that my code does not introduce a debug warning in my local environment.
- [ ] I have verified that the functional tests work in my local environment.
- [ ] I have verified that all automated tests pass or have provided a detailed comment about why I am submitting with a failed pipeline. (Leave unchecked if the repository does not include automated tests.)
- [ ] I have verified that any dependent changes have been merged and published in downstream commits.
- [ ] I have added a link to this Pull Request in the Asana task.
- [ ] I have moved the Asana task to "Ready for Functional Review".
- [ ] I have left a comment in Asana and GitHub tagging a team member with a request for `review.

## Testing

### How to test the changes in this pull request

<!-- Add the steps that should be followed in order to prepare for functional testing. This may include steps such as installing plugins or adding content to the dev site. -->

Follow the steps below to test the changes in this PR.

1. **By default**  
   * Visit `/author/some-author/` → should show your 404 template.  
2. **Opt-out via filter**  
   * Add the snippet above to a theme.  
   * Hard-refresh the same URL → the normal author archive should display.  
3. **Non-author pages** are untouched.

### Functional tests

<!-- Add the tests that should pass in order to approve functional testing. -->

As the functional tester for this pull request, I verify that:

- [ ] It [does something]
- [ ] It does not...
- [ ] As an admin, I can...
- [ ] As a user, I can...

Once testing is complete, notify the author of any failed tests and move the task to "Kick back" in Asana. If all tests pass, move the task to "Ready for Code Review" in Asana and tag a team member for code review.

### Code review

As the code reviewer for this pull request, I verify that:

- [ ] All automated tests have passed.
- [ ] The code is written (or documented) in a way that is easy to understand.
- [ ] The code is free of obvious errors and duplication.
- [ ] The code follows our coding standards.
- [ ] The code is sanitized or escaped appropriately for any SQL or XSS injection possibilities.

Once testing is complete, notify the author of any failed tests and move the task to "Kick back" in Asana or continue with the "merging" steps below.

## Merging

As the individual merging this pull request, I verify that:

- [ ] All automated tests have passed.
- [ ] All functional tests have passed.
- [ ] All code review tests have passed.
- [ ] I have moved the task to "Ready to Deploy" in Asana and notified the pull request author.
