### PR TITLE
Add login security and configurable security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,5 @@ All notable changes to this project will be documented in this file, per [the Ke
 ### Added
 
 - Userback toolbar toggle: Adds a button to the Full Site Editor toolbar that allows users to show or hide the Userback feedback widget while editing.
+- Login security: Blocks generic usernames, common passwords, and optionally pwned passwords via the Have I Been Pwned k-anonymity API. Configurable via settings.
+- Security headers: Configurable HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP) sent on all front-end, admin, and login pages.

--- a/src/MatchboxSupport/LoginSecurity.php
+++ b/src/MatchboxSupport/LoginSecurity.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Handles login security by blocking generic credentials.
+ *
+ * @since 2.1.0
+ *
+ * @package MatchboxSupport
+ */
+
+namespace MatchboxSupport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Login security class — blocks authentication with common/generic credentials.
+ *
+ * @since 2.1.0
+ */
+class LoginSecurity {
+
+	/**
+	 * Default list of blocked generic usernames (lowercase).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string>
+	 */
+	public const BLOCKED_USERNAMES = array(
+		'admin',
+		'administrator',
+		'demo',
+		'guest',
+		'info',
+		'manager',
+		'mysql',
+		'oracle',
+		'root',
+		'support',
+		'sysadmin',
+		'test',
+		'tester',
+		'testuser',
+		'user',
+		'webmaster',
+	);
+
+	/**
+	 * Default list of MD5 hashes of blocked common passwords.
+	 *
+	 * MD5 is used here solely for obfuscation — not for cryptographic
+	 * security. The submitted password arrives in plaintext via the
+	 * `authenticate` filter, so we MD5 it and compare against this list
+	 * to avoid storing plaintext passwords in source code.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string>
+	 */
+	private const BLOCKED_PASSWORD_HASHES = array(
+		'5f4dcc3b5aa765d61d8327deb882cf99',
+		'e10adc3949ba59abbe56e057f20f883e',
+		'd8578edf8458ce06fbc5bb76a58c5ca4',
+		'25d55ad283aa400af464c76d713c07ad',
+		'827ccb0eea8a706c4c34a16891f84e7b',
+		'e99a18c428cb38d5f260853678922e03',
+		'25f9e794323b453885f5181f1b624d0b',
+		'd0763edaa9d9bd2a9516280e9044d885',
+		'fcea920f7412b5da7be0cf42b8c93759',
+		'0d107d09f5bbe40cade3de5c71e9e9b7',
+		'5fcfd41e547a12215b173ff47fdd3739',
+		'7c6a180b36896a65c4c02c3514ae4240',
+		'6c569aabbf7775ef8fc570e228c16b98',
+		'3c3662bcb661d6de679c636744c66b62',
+		'f379eaf3c831b04de153469d1bec345e',
+		'96e79218965eb72c92a549dd5a330112',
+		'ee11cbb19052e40b07aac5ae8c4e15dc',
+	);
+
+	/**
+	 * Initialise login-security hooks.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_filter( 'authenticate', array( $this, 'block_generic_credentials' ), 30, 3 );
+		add_action( 'admin_head', array( $this, 'hide_weak_password_checkbox' ) );
+		add_action( 'login_head', array( $this, 'hide_weak_password_checkbox' ) );
+	}
+
+	/**
+	 * Hide the "Confirm use of weak password" checkbox on user profile
+	 * and password reset screens, preventing users from opting into
+	 * weak passwords.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function hide_weak_password_checkbox(): void {
+		if ( ! get_option( 'matchbox_hide_weak_password_checkbox', false ) ) {
+			return;
+		}
+
+		echo '<style>.pw-weak { display: none !important; }</style>' . "\n";
+	}
+
+	/**
+	 * Block authentication when generic credentials are used.
+	 *
+	 * Hooked to `authenticate` at priority 30 (after core authentication at 20).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param \WP_User|\WP_Error|null $user     Authenticated user, error, or null.
+	 * @param string                  $username  Submitted username.
+	 * @param string                  $password  Submitted password (plaintext).
+	 *
+	 * @return \WP_User|\WP_Error Authenticated user or error blocking login.
+	 */
+	public function block_generic_credentials( $user, string $username, string $password ) {
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
+
+		if ( $this->is_blocked_username( $username ) ) {
+			return new \WP_Error(
+				'matchbox_blocked_username',
+				__( '<strong>Error:</strong> This username is not permitted. Please contact your site administrator to set up a unique account.', 'matchbox-support' )
+			);
+		}
+
+		if ( $this->is_blocked_password( $password ) ) {
+			return new \WP_Error(
+				'matchbox_blocked_password',
+				__( '<strong>Error:</strong> This password is too common and not permitted. Please reset your password to something more secure.', 'matchbox-support' )
+			);
+		}
+
+		/**
+		 * Filter whether the HIBP Pwned Passwords check is enabled.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param bool $enabled Whether the check is enabled.
+		 */
+		$hibp_enabled = apply_filters(
+			'matchbox_hibp_check_enabled',
+			(bool) get_option( 'matchbox_enable_hibp_check', false )
+		);
+
+		if ( $hibp_enabled && $this->is_pwned_password( $password ) ) {
+			return new \WP_Error(
+				'matchbox_pwned_password',
+				__( '<strong>Error:</strong> This password has appeared in a known data breach and is not permitted. Please reset your password to something more secure.', 'matchbox-support' )
+			);
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Check whether a username is in the blocked list.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $username Username to check.
+	 *
+	 * @return bool True if the username is blocked.
+	 */
+	private function get_blocked_usernames(): array {
+		$saved = get_option( 'matchbox_blocked_usernames', '' );
+
+		if ( ! empty( $saved ) ) {
+			return array_values( array_filter(
+				array_map( 'trim', explode( "\n", strtolower( $saved ) ) )
+			) );
+		}
+
+		return self::BLOCKED_USERNAMES;
+	}
+
+	private function is_blocked_username( string $username ): bool {
+		/**
+		 * Filter the list of blocked generic usernames.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array<string> $blocked_usernames List of blocked usernames (lowercase).
+		 */
+		$blocked_usernames = apply_filters( 'matchbox_blocked_usernames', $this->get_blocked_usernames() );
+
+		return in_array( strtolower( trim( $username ) ), $blocked_usernames, true );
+	}
+
+	/**
+	 * Check whether a password matches a known common password hash.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $password Plaintext password to check.
+	 *
+	 * @return bool True if the password is blocked.
+	 */
+	private function is_blocked_password( string $password ): bool {
+		/**
+		 * Filter the list of MD5 hashes of blocked common passwords.
+		 *
+		 * To add a password to the blocked list, append its MD5 hash:
+		 * `md5( 'the-password-string' )`.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array<string> $blocked_password_hashes List of MD5 hex-digest hashes.
+		 */
+		$blocked_password_hashes = apply_filters( 'matchbox_blocked_password_hashes', self::BLOCKED_PASSWORD_HASHES );
+
+		return in_array( md5( $password ), $blocked_password_hashes, true );
+	}
+
+	/**
+	 * Check whether a password has been exposed in a data breach via the
+	 * Have I Been Pwned Pwned Passwords API (k-anonymity model).
+	 *
+	 * The full password or its full hash is never sent over the network.
+	 * Only the first 5 characters of the SHA-1 hash are transmitted.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $password Plaintext password to check.
+	 *
+	 * @return bool True if the password appears in a known breach.
+	 */
+	private function is_pwned_password( string $password ): bool {
+		$sha1   = strtoupper( sha1( $password ) );
+		$prefix = substr( $sha1, 0, 5 );
+		$suffix = substr( $sha1, 5 );
+
+		$response = wp_remote_get(
+			'https://api.pwnedpasswords.com/range/' . $prefix,
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Add-Padding' => 'true',
+					'User-Agent'  => 'MatchboxSupport/' . MATCHBOX_SUPPORT_VERSION,
+				),
+			)
+		);
+
+		// Fail open: if the API is unreachable, do not block login.
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$body  = wp_remote_retrieve_body( $response );
+		$lines = explode( "\r\n", $body );
+
+		foreach ( $lines as $line ) {
+			if ( empty( $line ) ) {
+				continue;
+			}
+
+			$parts = explode( ':', $line );
+
+			if ( count( $parts ) < 2 ) {
+				continue;
+			}
+
+			$hash_suffix = $parts[0];
+			$count       = (int) $parts[1];
+
+			// Skip padded entries.
+			if ( 0 === $count ) {
+				continue;
+			}
+
+			if ( strtoupper( $hash_suffix ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/MatchboxSupport/Plugin.php
+++ b/src/MatchboxSupport/Plugin.php
@@ -36,6 +36,16 @@ class Plugin {
 	private API $api;
 
 	/**
+	 * Login-security helper instance.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var LoginSecurity
+	 */
+	private LoginSecurity $login_security;
+
+
+	/**
 	 * Plugin path.
 	 *
 	 * @since 1.0.0
@@ -96,6 +106,10 @@ class Plugin {
 
 		$this->api = new API();
 		$this->api->init();
+
+		$this->login_security = new LoginSecurity();
+		$this->login_security->init();
+
 	}
 
 	/**
@@ -330,6 +344,46 @@ class Plugin {
 
 		add_filter( 'pre_update_option_matchbox_userback_token', [ $this, 'validate_userback_token' ], 10, 2 );
 		add_filter( 'pre_update_option_matchbox_helpscout_beacon_id', [ $this, 'validate_helpscout_beacon_id' ], 10, 2 );
+
+		register_setting( 'matchbox-support', 'matchbox_enable_hibp_check' );
+		register_setting( 'matchbox-support', 'matchbox_hide_weak_password_checkbox' );
+		register_setting(
+			'matchbox-support',
+			'matchbox_blocked_usernames',
+			array( 'sanitize_callback' => array( $this, 'sanitize_blocked_usernames' ) )
+		);
+
+		add_settings_section(
+			'matchbox_login_security_section',
+			'Login Security',
+			[ $this, 'login_security_section_cb' ],
+			'matchbox-support'
+		);
+
+		add_settings_field(
+			'matchbox_enable_hibp_check',
+			'Have I Been Pwned Check',
+			[ $this, 'hibp_check_field_cb' ],
+			'matchbox-support',
+			'matchbox_login_security_section'
+		);
+
+		add_settings_field(
+			'matchbox_hide_weak_password_checkbox',
+			'Weak Password Checkbox',
+			[ $this, 'hide_weak_password_field_cb' ],
+			'matchbox-support',
+			'matchbox_login_security_section'
+		);
+
+		add_settings_field(
+			'matchbox_blocked_usernames',
+			'Blocked Usernames',
+			[ $this, 'blocked_usernames_field_cb' ],
+			'matchbox-support',
+			'matchbox_login_security_section'
+		);
+
 	}
 
 
@@ -378,6 +432,82 @@ class Plugin {
 			echo '<span style="display:inline-block; vertical-align:middle; margin-left:8px;" title="Invalid token"><svg width="20" height="20" viewBox="0 0 20 20" style="vertical-align:middle;"><circle cx="10" cy="10" r="9" fill="#dc3545"/><path d="M6 6l8 8M14 6l-8 8" stroke="#fff" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
 		}
 	}
+
+	/**
+	 * Callback for the Login Security settings section description.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function login_security_section_cb() {
+		echo '<p>Configure login security settings. Generic usernames and common passwords are always blocked.</p>';
+	}
+
+	/**
+	 * Callback for rendering the HIBP check toggle field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function hibp_check_field_cb() {
+		$value = get_option( 'matchbox_enable_hibp_check', false );
+		echo '<label for="matchbox_enable_hibp_check">';
+		echo '<input type="checkbox" id="matchbox_enable_hibp_check" name="matchbox_enable_hibp_check" value="1"' . checked( $value, '1', false ) . ' />';
+		echo ' Enable Have I Been Pwned password check';
+		echo '</label>';
+		echo '<p class="description">When enabled, passwords are checked against the <a href="https://haveibeenpwned.com/Passwords" target="_blank" rel="noopener noreferrer">Have I Been Pwned</a> database on login using a privacy-preserving API (k-anonymity). The full password is never sent over the network.</p>';
+	}
+
+	/**
+	 * Callback for rendering the hide weak password checkbox toggle field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function hide_weak_password_field_cb() {
+		$value = get_option( 'matchbox_hide_weak_password_checkbox', false );
+		echo '<label for="matchbox_hide_weak_password_checkbox">';
+		echo '<input type="checkbox" id="matchbox_hide_weak_password_checkbox" name="matchbox_hide_weak_password_checkbox" value="1"' . checked( $value, '1', false ) . ' />';
+		echo ' Hide "Confirm use of weak password" checkbox';
+		echo '</label>';
+		echo '<p class="description">When enabled, the checkbox that allows users to bypass the weak password warning is hidden on profile and password reset screens.</p>';
+	}
+
+	/**
+	 * Callback for rendering the blocked usernames textarea field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function blocked_usernames_field_cb() {
+		$value = get_option( 'matchbox_blocked_usernames', '' );
+		echo '<textarea id="matchbox_blocked_usernames" name="matchbox_blocked_usernames" rows="10" cols="40" placeholder="' . esc_attr( implode( "\n", LoginSecurity::BLOCKED_USERNAMES ) ) . '">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description">One username per line. Usernames are case-insensitive. Leave blank to use the built-in default list.</p>';
+	}
+
+	/**
+	 * Sanitize the blocked usernames option.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $value Raw textarea value.
+	 *
+	 * @return string Sanitized newline-separated list of lowercase usernames.
+	 */
+	public function sanitize_blocked_usernames( string $value ): string {
+		$lines = array_filter(
+			array_map(
+				fn( $line ) => strtolower( sanitize_text_field( trim( $line ) ) ),
+				explode( "\n", $value )
+			)
+		);
+		return implode( "\n", array_values( $lines ) );
+	}
+
 
 	/**
 	 * Disables block recommendations from 3rd-party plugins in the block editor.

--- a/src/MatchboxSupport/Plugin.php
+++ b/src/MatchboxSupport/Plugin.php
@@ -44,6 +44,14 @@ class Plugin {
 	 */
 	private LoginSecurity $login_security;
 
+	/**
+	 * Security-headers helper instance.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var SecurityHeaders
+	 */
+	private SecurityHeaders $security_headers;
 
 	/**
 	 * Plugin path.
@@ -110,6 +118,8 @@ class Plugin {
 		$this->login_security = new LoginSecurity();
 		$this->login_security->init();
 
+		$this->security_headers = new SecurityHeaders();
+		$this->security_headers->init();
 	}
 
 	/**
@@ -384,6 +394,71 @@ class Plugin {
 			'matchbox_login_security_section'
 		);
 
+		register_setting( 'matchbox-support', 'matchbox_header_hsts' );
+		register_setting( 'matchbox-support', 'matchbox_header_xcto' );
+		register_setting( 'matchbox-support', 'matchbox_header_xfo' );
+		register_setting( 'matchbox-support', 'matchbox_header_xfo_value' );
+		register_setting( 'matchbox-support', 'matchbox_header_referrer' );
+		register_setting( 'matchbox-support', 'matchbox_header_referrer_value' );
+		register_setting( 'matchbox-support', 'matchbox_header_permissions' );
+		register_setting( 'matchbox-support', 'matchbox_header_permissions_value' );
+		register_setting( 'matchbox-support', 'matchbox_header_csp' );
+		register_setting( 'matchbox-support', 'matchbox_header_csp_value' );
+
+		add_settings_section(
+			'matchbox_security_headers_section',
+			'Security Headers',
+			[ $this, 'security_headers_section_cb' ],
+			'matchbox-support'
+		);
+
+		add_settings_field(
+			'matchbox_header_hsts',
+			'Strict-Transport-Security',
+			[ $this, 'header_hsts_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
+
+		add_settings_field(
+			'matchbox_header_xcto',
+			'X-Content-Type-Options',
+			[ $this, 'header_xcto_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
+
+		add_settings_field(
+			'matchbox_header_xfo',
+			'X-Frame-Options',
+			[ $this, 'header_xfo_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
+
+		add_settings_field(
+			'matchbox_header_referrer',
+			'Referrer-Policy',
+			[ $this, 'header_referrer_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
+
+		add_settings_field(
+			'matchbox_header_permissions',
+			'Permissions-Policy',
+			[ $this, 'header_permissions_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
+
+		add_settings_field(
+			'matchbox_header_csp',
+			'Content-Security-Policy',
+			[ $this, 'header_csp_field_cb' ],
+			'matchbox-support',
+			'matchbox_security_headers_section'
+		);
 	}
 
 
@@ -508,6 +583,139 @@ class Plugin {
 		return implode( "\n", array_values( $lines ) );
 	}
 
+	/**
+	 * Callback for the Security Headers settings section description.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function security_headers_section_cb() {
+		echo '<p>Configure HTTP security headers sent on all front-end, admin, and login pages. All headers default to <strong>off</strong> — enabling them on an existing site is safe, but review each header\'s value before enabling.</p>';
+	}
+
+	/**
+	 * Callback for rendering the Strict-Transport-Security header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_hsts_field_cb() {
+		$enabled = get_option( 'matchbox_header_hsts', false );
+		echo '<label for="matchbox_header_hsts">';
+		echo '<input type="checkbox" id="matchbox_header_hsts" name="matchbox_header_hsts" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable Strict-Transport-Security header';
+		echo '</label>';
+		echo '<p class="description">Fixed value: <code>max-age=31536000; includeSubDomains</code><br><strong>Warning:</strong> Only enable this on sites fully served over HTTPS. Once sent, browsers will refuse HTTP connections for the duration of <code>max-age</code>.</p>';
+	}
+
+	/**
+	 * Callback for rendering the X-Content-Type-Options header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_xcto_field_cb() {
+		$enabled = get_option( 'matchbox_header_xcto', false );
+		echo '<label for="matchbox_header_xcto">';
+		echo '<input type="checkbox" id="matchbox_header_xcto" name="matchbox_header_xcto" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable X-Content-Type-Options header';
+		echo '</label>';
+		echo '<p class="description">Fixed value: <code>nosniff</code>. Prevents browsers from MIME-sniffing responses away from the declared content type.</p>';
+	}
+
+	/**
+	 * Callback for rendering the X-Frame-Options header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_xfo_field_cb() {
+		$enabled = get_option( 'matchbox_header_xfo', false );
+		$value   = get_option( 'matchbox_header_xfo_value', 'SAMEORIGIN' );
+		echo '<label for="matchbox_header_xfo">';
+		echo '<input type="checkbox" id="matchbox_header_xfo" name="matchbox_header_xfo" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable X-Frame-Options header';
+		echo '</label>';
+		echo '<br><br>';
+		echo '<select id="matchbox_header_xfo_value" name="matchbox_header_xfo_value">';
+		foreach ( array( 'SAMEORIGIN', 'DENY' ) as $option ) {
+			echo '<option value="' . esc_attr( $option ) . '"' . selected( $value, $option, false ) . '>' . esc_html( $option ) . '</option>';
+		}
+		echo '</select>';
+		echo '<p class="description">Prevents the site from being embedded in an <code>&lt;iframe&gt;</code>. <code>SAMEORIGIN</code> allows same-origin embeds; <code>DENY</code> blocks all framing.</p>';
+	}
+
+	/**
+	 * Callback for rendering the Referrer-Policy header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_referrer_field_cb() {
+		$enabled = get_option( 'matchbox_header_referrer', false );
+		$value   = get_option( 'matchbox_header_referrer_value', 'strict-origin-when-cross-origin' );
+		$options = array(
+			'strict-origin-when-cross-origin',
+			'no-referrer',
+			'same-origin',
+			'origin',
+			'no-referrer-when-downgrade',
+		);
+		echo '<label for="matchbox_header_referrer">';
+		echo '<input type="checkbox" id="matchbox_header_referrer" name="matchbox_header_referrer" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable Referrer-Policy header';
+		echo '</label>';
+		echo '<br><br>';
+		echo '<select id="matchbox_header_referrer_value" name="matchbox_header_referrer_value">';
+		foreach ( $options as $option ) {
+			echo '<option value="' . esc_attr( $option ) . '"' . selected( $value, $option, false ) . '>' . esc_html( $option ) . '</option>';
+		}
+		echo '</select>';
+		echo '<p class="description">Controls how much referrer information is included with requests. <code>strict-origin-when-cross-origin</code> is the recommended default.</p>';
+	}
+
+	/**
+	 * Callback for rendering the Permissions-Policy header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_permissions_field_cb() {
+		$enabled = get_option( 'matchbox_header_permissions', false );
+		$value   = get_option( 'matchbox_header_permissions_value', 'camera=(), microphone=(), geolocation=()' );
+		echo '<label for="matchbox_header_permissions">';
+		echo '<input type="checkbox" id="matchbox_header_permissions" name="matchbox_header_permissions" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable Permissions-Policy header';
+		echo '</label>';
+		echo '<br><br>';
+		echo '<textarea id="matchbox_header_permissions_value" name="matchbox_header_permissions_value" rows="3" cols="60">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description">Restricts access to browser features. Default disables camera, microphone, and geolocation. Each directive follows the format <code>feature=()</code> to deny or <code>feature=(*)</code> to allow.</p>';
+	}
+
+	/**
+	 * Callback for rendering the Content-Security-Policy header field.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function header_csp_field_cb() {
+		$enabled = get_option( 'matchbox_header_csp', false );
+		$value   = get_option( 'matchbox_header_csp_value', 'upgrade-insecure-requests' );
+		echo '<label for="matchbox_header_csp">';
+		echo '<input type="checkbox" id="matchbox_header_csp" name="matchbox_header_csp" value="1"' . checked( $enabled, '1', false ) . ' />';
+		echo ' Enable Content-Security-Policy header';
+		echo '</label>';
+		echo '<br><br>';
+		echo '<textarea id="matchbox_header_csp_value" name="matchbox_header_csp_value" rows="3" cols="60">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description"><strong>Warning:</strong> A strict CSP can break site functionality (scripts, styles, inline code). The default <code>upgrade-insecure-requests</code> is safe for most sites. Test carefully before deploying a custom policy.</p>';
+	}
 
 	/**
 	 * Disables block recommendations from 3rd-party plugins in the block editor.

--- a/src/MatchboxSupport/SecurityHeaders.php
+++ b/src/MatchboxSupport/SecurityHeaders.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Handles configurable HTTP security headers.
+ *
+ * @since 2.1.0
+ *
+ * @package MatchboxSupport
+ */
+
+namespace MatchboxSupport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Sends optional security headers on front-end, admin, and login pages.
+ *
+ * @since 2.1.0
+ */
+class SecurityHeaders {
+
+	/**
+	 * Map of supported security headers to their option names and default values.
+	 *
+	 * Each entry contains:
+	 *   - option  (string)      WordPress option name for the enable/disable toggle.
+	 *   - value   (string|null) WordPress option name for the header value, or null
+	 *                           when the value is fixed (see `default`).
+	 *   - default (string)      Default header value used when `value` is null or the
+	 *                           value option has not been saved.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string, array{option: string, value: string|null, default: string}>
+	 */
+	private const HEADERS = array(
+		'Strict-Transport-Security' => array(
+			'option'  => 'matchbox_header_hsts',
+			'value'   => null,
+			'default' => 'max-age=31536000; includeSubDomains',
+		),
+		'X-Content-Type-Options'    => array(
+			'option'  => 'matchbox_header_xcto',
+			'value'   => null,
+			'default' => 'nosniff',
+		),
+		'X-Frame-Options'           => array(
+			'option'  => 'matchbox_header_xfo',
+			'value'   => 'matchbox_header_xfo_value',
+			'default' => 'SAMEORIGIN',
+		),
+		'Referrer-Policy'           => array(
+			'option'  => 'matchbox_header_referrer',
+			'value'   => 'matchbox_header_referrer_value',
+			'default' => 'strict-origin-when-cross-origin',
+		),
+		'Permissions-Policy'        => array(
+			'option'  => 'matchbox_header_permissions',
+			'value'   => 'matchbox_header_permissions_value',
+			'default' => 'camera=(), microphone=(), geolocation=()',
+		),
+		'Content-Security-Policy'   => array(
+			'option'  => 'matchbox_header_csp',
+			'value'   => 'matchbox_header_csp_value',
+			'default' => 'upgrade-insecure-requests',
+		),
+	);
+
+	/**
+	 * Initialise security-header hooks.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_action( 'send_headers', array( $this, 'send_security_headers' ) );
+		add_action( 'admin_init',   array( $this, 'send_security_headers' ) );
+		add_action( 'login_init',   array( $this, 'send_security_headers' ) );
+	}
+
+	/**
+	 * Send all enabled security headers.
+	 *
+	 * Iterates the header map, checks which headers are toggled on, resolves
+	 * the value for each, applies the `matchbox_security_headers` filter, then
+	 * calls PHP's header() for each entry.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return void
+	 */
+	public function send_security_headers(): void {
+		if ( headers_sent() ) {
+			return;
+		}
+
+		$headers = array();
+
+		foreach ( self::HEADERS as $header_name => $config ) {
+			if ( ! get_option( $config['option'], false ) ) {
+				continue;
+			}
+
+			$value = $config['value']
+				? get_option( $config['value'], $config['default'] )
+				: $config['default'];
+
+			if ( ! empty( $value ) ) {
+				$headers[ $header_name ] = $value;
+			}
+		}
+
+		/**
+		 * Filter all enabled security headers before they are sent.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array<string, string> $headers Associative array of header name => value.
+		 */
+		$headers = apply_filters( 'matchbox_security_headers', $headers );
+
+		foreach ( $headers as $name => $value ) {
+			header( sanitize_text_field( $name ) . ': ' . sanitize_text_field( $value ) );
+		}
+	}
+}


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds two new security features to the Matchbox Support plugin:

1. **Login Security** — blocks authentication with generic usernames (e.g. `admin`, `root`), common passwords (MD5-hashed block list), and optionally checks passwords against the [Have I Been Pwned](https://haveibeenpwned.com/Passwords) Pwned Passwords API using a privacy-preserving k-anonymity model (only the first 5 characters of the SHA-1 hash are transmitted). All three controls are configurable from the settings page.

2. **Security Headers** — sends configurable HTTP security headers on all front-end, admin, and login pages: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Content-Security-Policy`. All headers default to off; each can be individually enabled with selectable/editable values from the settings page.

Closes #

## Pre-submit checklist

As the author of this pull request, I verify that:

- [x] I have set the target branch to `main`.
- [x] I have detailed the purpose of this Pull Request in a non-technical way.
- [x] I have detailed how to test the changes in the Pull Request.
- [x] I have detailed the functional tests required for approval.
- [x] I have performed a self-review of my code to ensure it is DRY and follows the team's coding standards.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have verified that my code does not introduce a debug warning in my local environment.
- [ ] I have verified that the functional tests work in my local environment.
- [ ] I have verified that all automated tests pass or have provided a detailed comment about why I am submitting with a failed pipeline. (Leave unchecked if the repository does not include automated tests.)
- [x] I have verified that any dependent changes have been merged and published in downstream commits.
- [ ] I have added a link to this Pull Request in the Asana task.
- [ ] I have moved the Asana task to "Ready for Functional Review".
- [ ] I have left a comment in Asana and GitHub tagging a team member with a request for `review.

## Testing

### How to test the changes in this pull request

Follow the steps below to test the changes in this PR.

1. Download this branch [zip](https://github.com/matchboxdesigngroup/matchbox-support/archive/refs/heads/feat/fire-protection-features.zip) and install on a test WordPress site
2. Navigate to **Settings → Matchbox Support**.
3. Scroll to the **Login Security** section and enable the desired options (HIBP check, weak password checkbox, or custom blocked usernames).
4. Scroll to the **Security Headers** section and enable one or more headers, adjusting values as needed.
5. Save settings.

### Functional tests

As the functional tester for this pull request, I verify that:

- [ ] Attempting to log in with a blocked username (e.g. `admin`) returns an appropriate error message.
- [ ] Attempting to log in with a common password (e.g. `password`, `123456`) returns an appropriate error message.
- [ ] With HIBP check enabled, attempting to log in with a known-pwned password returns an appropriate error message.
- [ ] With HIBP check disabled, no API call is made and login is not blocked by the pwned-password check.
- [ ] With "Hide weak password checkbox" enabled, the "Confirm use of weak password" checkbox is not visible on the profile or password reset screens.
- [ ] Enabled security headers are present in HTTP responses on the front end, admin, and login pages (verify via browser DevTools → Network).
- [ ] Disabled headers are absent from responses.
- [ ] Custom header values (e.g. custom X-Frame-Options or CSP) are reflected correctly in responses.
- [ ] No PHP errors or debug warnings appear in any scenario.

Once testing is complete, notify the author of any failed tests and move the task to "Kick back" in Asana. If all tests pass, move the task to "Ready for Code Review" in Asana and tag a team member for code review.

### Code review

As the code reviewer for this pull request, I verify that:

- [x] All automated tests have passed.
- [ ] The code is written (or documented) in a way that is easy to understand.
- [ ] The code is free of obvious errors and duplication.
- [ ] The code follows our coding standards.
- [ ] The code is sanitized or escaped appropriately for any SQL or XSS injection possibilities.

Once testing is complete, notify the author of any failed tests and move the task to "Kick back" in Asana or continue with the "merging" steps below.

## Merging

As the individual merging this pull request, I verify that:

- [ ] All automated tests have passed.
- [ ] All functional tests have passed.
- [ ] All code review tests have passed.
- [ ] I have moved the task to "Ready to Deploy" in Asana and notified the pull request author.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213417588654411